### PR TITLE
Fix code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/plugins/external/spectrum.js
+++ b/plugins/external/spectrum.js
@@ -294,12 +294,12 @@
             }
             else {
 
-                var appendTo = opts.appendTo === "parent" ? boundElement.parent() : $(opts.appendTo);
+                var appendTo = opts.appendTo === "parent" ? boundElement.parent() : $.find(opts.appendTo);
                 if (appendTo.length !== 1) {
                     appendTo = $("body");
                 }
 
-                appendTo.append(container);
+                $(appendTo).append(container);
             }
 
             updateSelectionPaletteFromStorage();


### PR DESCRIPTION
Fixes [https://github.com/McBen/ingress-intel-total-conversion-R/security/code-scanning/6](https://github.com/McBen/ingress-intel-total-conversion-R/security/code-scanning/6)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
